### PR TITLE
Do not exit if open.Run() fail, just print to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func Main(args []string) error {
 	url := fmt.Sprintf("http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port)
 	if !noBrowser {
 		if err := open.Run(url); err != nil {
-			return err
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 	fmt.Println(url)


### PR DESCRIPTION
When fail to open web browser, I don't want re run www command adding `-n` option.

![image](https://user-images.githubusercontent.com/4487291/135557208-8049355f-33f6-4091-bdb2-04d91b40499a.png)
