### PR TITLE
Update go to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pocke/www
 
-go 1.17
+go 1.19
 
 require (
 	github.com/pocke/hlog v0.0.0-20150607034726-feb43ebeea3d


### PR DESCRIPTION
Current released binary raises GLIBC not found error.
So update binary to built by latest go